### PR TITLE
[WIP] fix: disable autobreadcrumbs

### DIFF
--- a/src/sentry.js
+++ b/src/sentry.js
@@ -66,7 +66,7 @@ module.exports = (SentryLib) => {
       const sentryConfig = _.cloneDeep(config);
 
       _.defaults(sentryConfig, {
-        autoBreadcrumbs: true,
+        autoBreadcrumbs: false,
         allowSecretKey: true,
         dataCallback: utils.hideAbsolutePathsInObject
       });


### PR DESCRIPTION
We disable the `autoBreadcrumbs` option in Raven such that no
information is sent implicitly.

See: https://github.com/resin-io-modules/resin-corvus/issues/18