### PR TITLE
fix: plainify error objects for console

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -118,13 +118,10 @@ exports.hideAbsolutePathsInObject = (object) => {
   if (_.isError(object)) {
 
     // Turn the Error into an Object
-    const error = {};
-
-    _.map(Object.getOwnPropertyNames(object), (key) => {
-      error[key] = object[key];
-    });
-
-    object = error;
+    object = _.reduce(Object.getOwnPropertyNames(object), (accumulator, key) => {
+      accumulator[key] = object[key];
+      return accumulator;
+    }, {});
   }
 
   if (_.isString(object)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,6 +115,18 @@ exports.flattenStartCase = (object) => {
  * > }
  */
 exports.hideAbsolutePathsInObject = (object) => {
+  if (_.isError(object)) {
+
+    // Turn the Error into an Object
+    const error = {};
+
+    _.map(Object.getOwnPropertyNames(object), (key) => {
+      error[key] = object[key];
+    });
+
+    object = error;
+  }
+
   if (_.isString(object)) {
     const words = object.split(' ').map(word => (path.isAbsolute(word) ? path.basename(word) : word));
     return words.join(' ');

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -157,6 +157,16 @@ describe('Utils', () => {
       chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal(object);
     });
 
+    it('should return a plain object when given an error object', function() {
+      const error = new Error('Hello, World!');
+      const hiddenPaths = utils.hideAbsolutePathsInObject(error);
+
+      chai.expect(hiddenPaths).to.deep.equal({
+        message: 'Hello, World!',
+        stack: error.stack
+      });
+    });
+
     describe('given UNIX paths', () => {
       beforeEach(() => {
         this.isAbsolute = path.isAbsolute;


### PR DESCRIPTION
We make error objects into plain objects and `JSON.stringify` them the
same, such that they no longer appear as empty objects.