### PR TITLE
fix(mixpanel): Use HTTPS transport

### DIFF
--- a/src/mixpanel.js
+++ b/src/mixpanel.js
@@ -38,8 +38,8 @@ module.exports = (MixpanelLib) => {
      *
      * @example
      * if (mixpanel.isInstalled()) {
-   *   console.log('Mixpanel is installed');
-   * }
+     *   console.log('Mixpanel is installed');
+     * }
      */
     isInstalled,
 
@@ -61,7 +61,7 @@ module.exports = (MixpanelLib) => {
         throw new Error('Mixpanel already installed');
       }
 
-      properties.client = MixpanelLib.init(token) || MixpanelLib;
+      properties.client = MixpanelLib.init(token, { protocol: 'https' }) || MixpanelLib;
       properties.context = utils.flattenStartCase(_.defaults(config, defaultContext[env]));
       properties.installed = true;
     },


### PR DESCRIPTION
This forces the mixpanel module to use HTTPS as a transport,
as it defaults to HTTP.

Change-Type: patch
Connects To: https://github.com/resin-io/etcher/issues/1718
See Also: https://github.com/mixpanel/mixpanel-node/pull/122