### PR TITLE
fix(sentry): Default to HTTPS transport

### DIFF
--- a/src/sentry.js
+++ b/src/sentry.js
@@ -68,7 +68,8 @@ module.exports = (SentryLib) => {
       _.defaults(sentryConfig, {
         autoBreadcrumbs: true,
         allowSecretKey: true,
-        dataCallback: utils.hideAbsolutePathsInObject
+        dataCallback: utils.hideAbsolutePathsInObject,
+        transport: SentryLib.transports.https
       });
 
       sentryConfig.extra = _.defaults(sentryConfig.extra, defaultContext[env]);


### PR DESCRIPTION
This defaults Sentry's raven client to use HTTPS,
as this was also using HTTP by default.

Change-Type: patch
Connects To: https://github.com/resin-io-modules/resin-corvus/pull/25, https://github.com/resin-io/etcher/issues/1718