### PR TITLE
test: Use standardjs for linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "eslint-config-airbnb-base",
-  "rules": {
-    "comma-dangle": 0
-  }
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
 sudo: false
 node_js:
-  - "6.10.3"
-
+  - "8"
+  - "6"
+  - "4"
+script:
+  - npm run lint
+  - npm test
 notifications:
   email: false
   webhooks:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 environment:
-  nodejs_version: "6"
+  nodejs_version:
+    - "8"
+    - "6"
+    - "4"
 
 install:
   - ps: Install-Product node $env:nodejs_version
@@ -8,6 +11,7 @@ install:
 test_script:
   - node --version
   - npm --version
+  - npm run lint
   - npm test
 
 build: off

--- a/browser.js
+++ b/browser.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-const SentryLib = require('raven-js/dist/raven');
-const MixpanelLib = require('mixpanel-browser');
-const fake = require('./should-fake');
+const SentryLib = require('raven-js/dist/raven')
+const MixpanelLib = require('mixpanel-browser')
+const fake = require('./should-fake')
 
-module.exports = require('./src/resin-corvus')(SentryLib, MixpanelLib, fake);
+module.exports = require('./src/resin-corvus')(SentryLib, MixpanelLib, fake)

--- a/node.js
+++ b/node.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-const SentryLib = require('raven');
-const MixpanelLib = require('mixpanel');
-const fake = require('./should-fake');
+const SentryLib = require('raven')
+const MixpanelLib = require('mixpanel')
+const fake = require('./should-fake')
 
-module.exports = require('./src/resin-corvus')(SentryLib, MixpanelLib, fake);
+module.exports = require('./src/resin-corvus')(SentryLib, MixpanelLib, fake)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "browser": "browser.js",
   "scripts": {
     "test": "mocha --recursive tests",
-    "lint": "eslint ."
+    "lint": "standard ./*.js src/*.js && standard --env mocha tests/*.js",
+    "lint-fix": "standard --fix"
   },
   "repository": {
     "type": "git",
@@ -40,9 +41,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^3.3.0",
-    "eslint": "^3.17.1",
-    "eslint-config-airbnb-base": "^11.1.1",
-    "eslint-plugin-import": "^2.2.0",
-    "sinon": "^2.0.0"
+    "sinon": "^2.0.0",
+    "standard": "^10.0.3"
   }
 }

--- a/should-fake.js
+++ b/should-fake.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-const detect = require('detect-process');
-const isRunningInAsar = require('electron-is-running-in-asar');
+const detect = require('detect-process')
+const isRunningInAsar = require('electron-is-running-in-asar')
 
-const env = detect.getName();
+const env = detect.getName()
 
 // In Electron, we don't want to log to external services if we're not running in asar
-module.exports = env === 'electron' && !isRunningInAsar();
+module.exports = env === 'electron' && !isRunningInAsar()

--- a/src/default-context.js
+++ b/src/default-context.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-const arch = require('arch');
-const os = require('os');
-const osLocale = require('os-locale');
+const arch = require('arch')
+const os = require('os')
+const osLocale = require('os-locale')
 
 /**
  * @summary Get host architecture
@@ -36,10 +36,10 @@ const osLocale = require('os-locale');
  */
 const getHostArchitecture = () => {
   if (['ia32', 'x64'].includes(process.arch)) {
-    return arch().replace('x86', 'ia32');
+    return arch().replace('x86', 'ia32')
   }
-  return process.arch;
-};
+  return process.arch
+}
 
 module.exports.node = {
   arch: process.arch,
@@ -51,10 +51,10 @@ module.exports.node = {
   startFreeMemory: os.freemem(),
   hostArch: getHostArchitecture(),
   locale: osLocale.sync()
-};
+}
 
 module.exports.electron = Object.assign({}, module.exports.node, {
   electron: process.versions.electron
-});
+})
 
-module.exports.browser = {};
+module.exports.browser = {}

--- a/src/mixpanel.js
+++ b/src/mixpanel.js
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-const detect = require('detect-process');
-const utils = require('./utils');
-const defaultContext = require('./default-context');
-const _ = require('lodash');
+const detect = require('detect-process')
+const utils = require('./utils')
+const defaultContext = require('./default-context')
+const _ = require('lodash')
 
 module.exports = (MixpanelLib) => {
-  const env = detect.getName();
+  const env = detect.getName()
 
   const properties = {
     installed: false
-  };
+  }
 
-  const isInstalled = () => properties.installed;
+  const isInstalled = () => properties.installed
 
   return {
     /**
@@ -58,12 +58,12 @@ module.exports = (MixpanelLib) => {
      */
     install: (token, config) => {
       if (isInstalled()) {
-        throw new Error('Mixpanel already installed');
+        throw new Error('Mixpanel already installed')
       }
 
-      properties.client = MixpanelLib.init(token, { protocol: 'https' }) || MixpanelLib;
-      properties.context = utils.flattenStartCase(_.defaults(config, defaultContext[env]));
-      properties.installed = true;
+      properties.client = MixpanelLib.init(token, { protocol: 'https' }) || MixpanelLib
+      properties.context = utils.flattenStartCase(_.defaults(config, defaultContext[env]))
+      properties.installed = true
     },
 
     /**
@@ -76,10 +76,10 @@ module.exports = (MixpanelLib) => {
      */
     uninstall: () => {
       if (!isInstalled()) {
-        throw new Error('Mixpanel not installed');
+        throw new Error('Mixpanel not installed')
       }
 
-      properties.installed = false;
+      properties.installed = false
     },
 
     /**
@@ -92,12 +92,12 @@ module.exports = (MixpanelLib) => {
      */
     track: (message, data) => {
       if (!isInstalled()) {
-        throw new Error('Mixpanel not installed');
+        throw new Error('Mixpanel not installed')
       }
 
-      const context = Object.assign({}, properties.context, utils.flattenStartCase(data));
+      const context = Object.assign({}, properties.context, utils.flattenStartCase(data))
 
-      properties.client.track(message, utils.hideAbsolutePathsInObject(context));
+      properties.client.track(message, utils.hideAbsolutePathsInObject(context))
     }
-  };
-};
+  }
+}

--- a/src/resin-corvus.js
+++ b/src/resin-corvus.js
@@ -14,42 +14,42 @@
  * limitations under the License.
  */
 
-const _ = require('lodash');
-const Mixpanel = require('./mixpanel');
-const Sentry = require('./sentry');
-const utils = require('./utils');
+const _ = require('lodash')
+const Mixpanel = require('./mixpanel')
+const Sentry = require('./sentry')
+const utils = require('./utils')
 
 module.exports = (SentryLib, MixpanelLib, fake = false) => {
-  const sentry = Sentry(SentryLib);
-  const mixpanel = Mixpanel(MixpanelLib);
-  const installedServices = [];
-  let installed = false;
-  let enabled = true;
-  let consoleOutputDisabled = false;
+  const sentry = Sentry(SentryLib)
+  const mixpanel = Mixpanel(MixpanelLib)
+  const installedServices = []
+  let installed = false
+  let enabled = true
+  let consoleOutputDisabled = false
 
-  const getSupportedServices = () => ['sentry', 'mixpanel'];
+  const getSupportedServices = () => ['sentry', 'mixpanel']
 
   const logDebug = (message) => {
-    const debugMessage = `${new Date()} ${message}`;
+    const debugMessage = `${new Date()} ${message}`
 
     if (!consoleOutputDisabled) {
       /* eslint-disable no-console */
-      console.log(utils.hideAbsolutePathsInObject(debugMessage));
+      console.log(utils.hideAbsolutePathsInObject(debugMessage))
       /* eslint-enable no-console */
     }
-  };
+  }
 
-  let shouldReportCallback = _.constant(true);
+  let shouldReportCallback = _.constant(true)
 
   const setShouldReport = (callback) => {
     if (!_.isFunction(callback)) {
-      throw new Error('Function expected');
+      throw new Error('Function expected')
     } else {
-      shouldReportCallback = callback;
+      shouldReportCallback = callback
     }
-  };
+  }
 
-  const shouldSendToExternalServices = () => enabled && !fake && shouldReportCallback();
+  const shouldSendToExternalServices = () => enabled && !fake && shouldReportCallback()
 
   return {
 
@@ -84,7 +84,7 @@ module.exports = (SentryLib, MixpanelLib, fake = false) => {
      * resinCorvus.enable();
      */
     enable: () => {
-      enabled = true;
+      enabled = true
     },
 
     /**
@@ -96,7 +96,7 @@ module.exports = (SentryLib, MixpanelLib, fake = false) => {
      * resinCorvus.disable();
      */
     disable: () => {
-      enabled = false;
+      enabled = false
     },
 
     /**
@@ -143,25 +143,25 @@ module.exports = (SentryLib, MixpanelLib, fake = false) => {
      * });
      */
     install: (config) => {
-      consoleOutputDisabled = Boolean(config.options.disableConsoleOutput);
+      consoleOutputDisabled = Boolean(config.options.disableConsoleOutput)
 
       if (fake) {
-        return;
+        return
       }
 
       if (installed) {
-        throw new Error('Already installed');
+        throw new Error('Already installed')
       }
 
-      installed = true;
+      installed = true
 
       if (!_.isNil(config.options.shouldReport)) {
-        setShouldReport(config.options.shouldReport);
+        setShouldReport(config.options.shouldReport)
       }
 
       Object.keys(config.services).forEach((serviceName) => {
         if (!getSupportedServices().includes(serviceName)) {
-          throw new Error(`Service not supported: ${serviceName}`);
+          throw new Error(`Service not supported: ${serviceName}`)
         }
 
         if (serviceName === 'sentry' && !_.isNil(config.services.sentry)) {
@@ -169,19 +169,19 @@ module.exports = (SentryLib, MixpanelLib, fake = false) => {
             release: config.options.release,
             serverName: config.options.serverName,
             disableConsoleAlerts: consoleOutputDisabled
-          });
-          installedServices.push('sentry');
+          })
+          installedServices.push('sentry')
         }
 
         if (serviceName === 'mixpanel' && !_.isNil(config.services.mixpanel)) {
           mixpanel.install(config.services.mixpanel, {
             version: config.options.release,
             serverName: config.options.serverName
-          });
+          })
 
-          installedServices.push('mixpanel');
+          installedServices.push('mixpanel')
         }
-      });
+      })
     },
 
     /**
@@ -200,16 +200,16 @@ module.exports = (SentryLib, MixpanelLib, fake = false) => {
     logEvent: (message, data) => {
       const debugMessage = _.attempt(() => {
         if (data) {
-          return `${message} (${JSON.stringify(data)})`;
+          return `${message} (${JSON.stringify(data)})`
         }
 
-        return message;
-      });
+        return message
+      })
 
-      logDebug(debugMessage);
+      logDebug(debugMessage)
 
       if (shouldSendToExternalServices() && installedServices.includes('mixpanel')) {
-        mixpanel.track(message, data);
+        mixpanel.track(message, data)
       }
     },
 
@@ -223,15 +223,15 @@ module.exports = (SentryLib, MixpanelLib, fake = false) => {
     logException: (error) => {
       if (!consoleOutputDisabled) {
         /* eslint-disable no-console */
-        console.error(JSON.stringify(utils.hideAbsolutePathsInObject(error)));
+        console.error(JSON.stringify(utils.hideAbsolutePathsInObject(error)))
         /* eslint-disable no-console */
       }
 
       if (!installedServices.includes('sentry') || !shouldSendToExternalServices() || !utils.shouldReportError(error)) {
-        return;
+        return
       }
 
-      sentry.captureException(error);
+      sentry.captureException(error)
     },
 
     /**
@@ -249,7 +249,7 @@ module.exports = (SentryLib, MixpanelLib, fake = false) => {
      * @public
      */
     disableConsoleOutput: () => {
-      consoleOutputDisabled = true;
+      consoleOutputDisabled = true
     },
 
     /**
@@ -258,7 +258,7 @@ module.exports = (SentryLib, MixpanelLib, fake = false) => {
      * @public
      */
     enableConsoleOutput: () => {
-      consoleOutputDisabled = false;
+      consoleOutputDisabled = false
     }
-  };
-};
+  }
+}

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-const _ = require('lodash');
-const detect = require('detect-process');
-const defaultContext = require('./default-context');
-const utils = require('./utils');
+const _ = require('lodash')
+const detect = require('detect-process')
+const defaultContext = require('./default-context')
+const utils = require('./utils')
 
-const env = detect.getName();
+const env = detect.getName()
 
 module.exports = (SentryLib) => {
   const properties = {
     installed: false,
     enabled: true
-  };
+  }
 
   return {
 
@@ -60,22 +60,22 @@ module.exports = (SentryLib) => {
      */
     install: (dsn, config) => {
       if (properties.installed) {
-        throw new Error('Sentry already installed');
+        throw new Error('Sentry already installed')
       }
 
-      const sentryConfig = _.cloneDeep(config);
+      const sentryConfig = _.cloneDeep(config)
 
       _.defaults(sentryConfig, {
         autoBreadcrumbs: true,
         allowSecretKey: true,
         dataCallback: utils.hideAbsolutePathsInObject,
         transport: SentryLib.transports.https
-      });
+      })
 
-      sentryConfig.extra = _.defaults(sentryConfig.extra, defaultContext[env]);
+      sentryConfig.extra = _.defaults(sentryConfig.extra, defaultContext[env])
 
-      properties.client = SentryLib.config(dsn, sentryConfig).install();
-      properties.installed = true;
+      properties.client = SentryLib.config(dsn, sentryConfig).install()
+      properties.installed = true
     },
 
     /**
@@ -88,11 +88,11 @@ module.exports = (SentryLib) => {
      */
     uninstall: () => {
       if (!properties.installed) {
-        throw new Error('Sentry not installed');
+        throw new Error('Sentry not installed')
       }
 
-      properties.client.uninstall();
-      properties.installed = false;
+      properties.client.uninstall()
+      properties.installed = false
     },
 
     /**
@@ -105,17 +105,17 @@ module.exports = (SentryLib) => {
      */
     captureException: (exception) => {
       if (!properties.installed) {
-        throw new Error('Sentry not installed');
+        throw new Error('Sentry not installed')
       }
 
-      let transformedException = exception;
+      let transformedException = exception
       if (!_.isError(exception) && !_.isString(exception)) {
-        transformedException = JSON.stringify(exception);
+        transformedException = JSON.stringify(exception)
       }
 
       properties.client.captureException(transformedException, {
         stacktrace: false
-      });
+      })
     }
-  };
-};
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-const _ = require('lodash');
-_.mixin(require('lodash-deep'));
-const flatten = require('flat').flatten;
-const deepMapKeys = require('deep-map-keys');
-const path = require('path');
+const _ = require('lodash')
+_.mixin(require('lodash-deep'))
+const flatten = require('flat').flatten
+const deepMapKeys = require('deep-map-keys')
+const path = require('path')
 
 /**
  * @summary Prepare object for Mixpanel
@@ -48,41 +48,41 @@ const path = require('path');
  */
 exports.flattenStartCase = (object) => {
   if (_.isUndefined(object)) {
-    return undefined;
+    return undefined
   }
 
   // Transform primitives to objects
   if (!_.isObject(object)) {
     return {
-      Value: object,
-    };
+      Value: object
+    }
   }
 
   if (_.isArray(object)) {
     return _.map(object, (property) => {
       if (_.isObject(property)) {
-        return exports.flattenStartCase(property);
+        return exports.flattenStartCase(property)
       }
 
-      return property;
-    });
+      return property
+    })
   }
 
   const transformedKeysObject = deepMapKeys(object, (key) => {
     // Preserve environment variables
-    const regex = /^[A-Z_]+$/;
+    const regex = /^[A-Z_]+$/
     if (regex.test(key)) {
-      return key;
+      return key
     }
 
-    return _.startCase(key);
-  });
+    return _.startCase(key)
+  })
 
   return flatten(transformedKeysObject, {
     delimiter: ' ',
-    safe: true,
-  });
-};
+    safe: true
+  })
+}
 
 /**
  * @summary Create an object clone with all absolute paths replaced with the path basename
@@ -116,32 +116,31 @@ exports.flattenStartCase = (object) => {
  */
 exports.hideAbsolutePathsInObject = (object) => {
   if (_.isError(object)) {
-
     // Turn the Error into an Object
     object = _.reduce(Object.getOwnPropertyNames(object), (accumulator, key) => {
-      accumulator[key] = object[key];
-      return accumulator;
-    }, {});
+      accumulator[key] = object[key]
+      return accumulator
+    }, {})
   }
 
   if (_.isString(object)) {
-    const words = object.split(' ').map(word => (path.isAbsolute(word) ? path.basename(word) : word));
-    return words.join(' ');
+    const words = object.split(' ').map(word => (path.isAbsolute(word) ? path.basename(word) : word))
+    return words.join(' ')
   }
 
   return _.deepMapValues(object, (value) => {
     if (!_.isString(value)) {
-      return value;
+      return value
     }
 
     // Don't alter disk devices, even though they appear as full paths
     if (value.startsWith('/dev/') || value.startsWith('\\\\.\\')) {
-      return value;
+      return value
     }
 
-    return path.isAbsolute(value) ? path.basename(value) : value;
-  });
-};
+    return path.isAbsolute(value) ? path.basename(value) : value
+  })
+}
 
 /**
  * @summary Check whether an error should be reported to TrackJS
@@ -162,4 +161,4 @@ exports.hideAbsolutePathsInObject = (object) => {
  *   console.log('We should report this error');
  * }
  */
-exports.shouldReportError = error => !_.has(error, ['report']) || Boolean(error.report);
+exports.shouldReportError = error => !_.has(error, ['report']) || Boolean(error.report)

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "env": {
-    "mocha": true
-  },
-  "rules": {
-    "no-unused-expressions": "off"
-  }
-}

--- a/tests/mixpanel.js
+++ b/tests/mixpanel.js
@@ -14,59 +14,59 @@
  * limitations under the License.
  */
 
-const chai = require('chai');
-const sinon = require('sinon');
-const MixpanelLib = require('mixpanel');
-const Mixpanel = require('../src/mixpanel');
+const chai = require('chai')
+const sinon = require('sinon')
+const MixpanelLib = require('mixpanel')
+const Mixpanel = require('../src/mixpanel')
 
 describe('Services: Mixpanel', () => {
-  const mixpanel = Mixpanel(MixpanelLib);
-  const token = 'YOUR_TOKEN';
+  const mixpanel = Mixpanel(MixpanelLib)
+  const token = 'YOUR_TOKEN'
 
   beforeEach(() => {
-    sinon.spy(MixpanelLib, 'init');
-  });
+    sinon.spy(MixpanelLib, 'init')
+  })
 
   afterEach(() => {
     if (mixpanel.isInstalled()) {
-      mixpanel.uninstall();
+      mixpanel.uninstall()
     }
-    MixpanelLib.init.restore();
-  });
+    MixpanelLib.init.restore()
+  })
 
   describe('install()', () => {
     it('throws if mixpanel is already installed', () => {
-      mixpanel.install(token);
-      chai.expect(() => mixpanel.install(token)).to.throw(Error);
-    });
+      mixpanel.install(token)
+      chai.expect(() => mixpanel.install(token)).to.throw(Error)
+    })
 
     it('calls MixpanelLib.init() with correct parameters', () => {
-      mixpanel.install(token);
-      chai.expect(MixpanelLib.init.calledOnce).to.be.true;
-      chai.expect(MixpanelLib.init.calledWith(token)).to.be.true;
-    });
-  });
+      mixpanel.install(token)
+      chai.expect(MixpanelLib.init.calledOnce).to.equal(true)
+      chai.expect(MixpanelLib.init.calledWith(token)).to.equal(true)
+    })
+  })
 
   describe('isInstalled()', () => {
     it('is false when mixpanel is not installed', () => {
-      chai.expect(mixpanel.isInstalled()).to.be.false;
-    });
+      chai.expect(mixpanel.isInstalled()).to.equal(false)
+    })
 
     it('is true when mixpanel is installed', () => {
-      mixpanel.install(token);
-      chai.expect(mixpanel.isInstalled()).to.be.true;
-    });
+      mixpanel.install(token)
+      chai.expect(mixpanel.isInstalled()).to.equal(true)
+    })
 
     it('is false after uninstall', () => {
-      mixpanel.install(token);
-      mixpanel.uninstall();
-      chai.expect(mixpanel.isInstalled()).to.be.false;
-    });
-  });
+      mixpanel.install(token)
+      mixpanel.uninstall()
+      chai.expect(mixpanel.isInstalled()).to.equal(false)
+    })
+  })
 
   describe('uninstall()', () => {
     it('throws if mixpanel is not installed', () => {
-      chai.expect(() => mixpanel.uninstall()).to.throw(Error);
-    });
-  });
-});
+      chai.expect(() => mixpanel.uninstall()).to.throw(Error)
+    })
+  })
+})

--- a/tests/sentry.js
+++ b/tests/sentry.js
@@ -14,71 +14,70 @@
  * limitations under the License.
  */
 
-const chai = require('chai');
-const sinon = require('sinon');
-const SentryLib = require('raven');
-const Sentry = require('../src/sentry');
+const chai = require('chai')
+const sinon = require('sinon')
+const SentryLib = require('raven')
+const Sentry = require('../src/sentry')
 
 describe('Services: Sentry', () => {
-  const sentry = Sentry(SentryLib);
+  const sentry = Sentry(SentryLib)
 
-  const dsn = 'https://xxx:yyy@client.io/100000';
-  const release = '1.0.0';
+  const dsn = 'https://xxx:yyy@client.io/100000'
+  const release = '1.0.0'
 
   beforeEach(() => {
-    sinon.spy(SentryLib, 'config');
-    sinon.spy(SentryLib, 'install');
-    sinon.spy(SentryLib, 'uninstall');
-  });
+    sinon.spy(SentryLib, 'config')
+    sinon.spy(SentryLib, 'install')
+    sinon.spy(SentryLib, 'uninstall')
+  })
 
   afterEach(() => {
     if (sentry.isInstalled()) {
-      sentry.uninstall();
+      sentry.uninstall()
     }
-    SentryLib.config.restore();
-    SentryLib.install.restore();
-    SentryLib.uninstall.restore();
-  });
+    SentryLib.config.restore()
+    SentryLib.install.restore()
+    SentryLib.uninstall.restore()
+  })
 
   describe('install()', () => {
     it('throws if Sentry is already installed', () => {
-      sentry.install(dsn, release);
-      chai.expect(() => sentry.install(dsn, '2.0.0')).to.throw(Error);
-    });
+      sentry.install(dsn, release)
+      chai.expect(() => sentry.install(dsn, '2.0.0')).to.throw(Error)
+    })
 
     it('calls SentryLib.install() after SentryLib.config()', () => {
-      sentry.install(dsn, release);
-      chai.expect(SentryLib.install.calledAfter(SentryLib.config));
-    });
-  });
+      sentry.install(dsn, release)
+      chai.expect(SentryLib.install.calledAfter(SentryLib.config))
+    })
+  })
 
   describe('isInstalled()', () => {
     it('is false when sentry is not installed', () => {
-      chai.expect(sentry.isInstalled()).to.be.false;
-    });
+      chai.expect(sentry.isInstalled()).to.equal(false)
+    })
 
     it('is true when sentry is installed', () => {
-      sentry.install(dsn, release);
-      chai.expect(sentry.isInstalled()).to.be.true;
-    });
+      sentry.install(dsn, release)
+      chai.expect(sentry.isInstalled()).to.equal(true)
+    })
 
     it('is false after uninstall', () => {
-      sentry.install(dsn, release);
-      sentry.uninstall();
-      chai.expect(sentry.isInstalled()).to.be.false;
-    });
-  });
+      sentry.install(dsn, release)
+      sentry.uninstall()
+      chai.expect(sentry.isInstalled()).to.equal(false)
+    })
+  })
 
   describe('uninstall()', () => {
     it('throws if Sentry is not installed', () => {
-      chai.expect(() => sentry.uninstall()).to.throw(Error);
-    });
+      chai.expect(() => sentry.uninstall()).to.throw(Error)
+    })
 
     it('calls SentryLib.uninstall()', () => {
-      sentry.install(dsn, release);
-      sentry.uninstall();
-      chai.expect(SentryLib.uninstall.calledOnce).to.be.true;
-    });
-  });
-});
-
+      sentry.install(dsn, release)
+      sentry.uninstall()
+      chai.expect(SentryLib.uninstall.calledOnce).to.equal(true)
+    })
+  })
+})

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -30,15 +30,15 @@
  * limitations under the License.
  */
 
-const chai = require('chai');
-const path = require('path');
-const utils = require('../src/utils');
+const chai = require('chai')
+const path = require('path')
+const utils = require('../src/utils')
 
 describe('Utils', () => {
   describe('flattenStartCase()', () => {
     it('should return undefined if given undefined', () => {
-      chai.expect(utils.flattenStartCase(undefined)).to.be.undefined;
-    });
+      chai.expect(utils.flattenStartCase(undefined)).to.equal(undefined)
+    })
 
     it('should return flat object with start case keys if given nested object', () => {
       const object = {
@@ -50,101 +50,101 @@ describe('Utils', () => {
             streetName: 'Elm'
           }
         }
-      };
+      }
 
       chai.expect(utils.flattenStartCase(object)).to.deep.equal({
         'Person First Name': 'John',
         'Person Last Name': 'Doe',
         'Person Address Street Number': 13,
         'Person Address Street Name': 'Elm'
-      });
-    });
+      })
+    })
 
     it('should return an object with the key `value` if given `false`', () => {
       chai.expect(utils.flattenStartCase(false)).to.deep.equal({
         Value: false
-      });
-    });
+      })
+    })
 
     it('should return an object with the key `value` if given `null`', () => {
       chai.expect(utils.flattenStartCase(null)).to.deep.equal({
         Value: null
-      });
-    });
+      })
+    })
 
     it('should preserve environment variable', () => {
       chai.expect(utils.flattenStartCase({
         ETCHER_DISABLE_UPDATES: true
       })).to.deep.equal({
         ETCHER_DISABLE_UPDATES: true
-      });
-    });
+      })
+    })
 
     it('should preserve environment variables inside objects', () => {
       chai.expect(utils.flattenStartCase({
         foo: {
           FOO_BAR_BAZ: 3
-        },
+        }
       })).to.deep.equal({
         'Foo FOO_BAR_BAZ': 3
-      });
-    });
+      })
+    })
 
     it('should insert space after key starting with number', () => {
       chai.expect(utils.flattenStartCase({
         foo: {
           '1key': 1
-        },
+        }
       })).to.deep.equal({
         'Foo 1 Key': 1
-      });
-    });
+      })
+    })
 
     it('should not modify start case keys', () => {
       chai.expect(utils.flattenStartCase({
         Foo: {
           'Start Case Key': 42
-        },
+        }
       })).to.deep.equal({
         'Foo Start Case Key': 42
-      });
-    });
+      })
+    })
 
     it('should not modify arrays', () => {
       chai.expect(utils.flattenStartCase([1, 2, {
         nested: 3
       }])).to.deep.equal([1, 2, {
         Nested: 3
-      }]);
-    });
+      }])
+    })
 
     it('should not modify nested arrays', () => {
       chai.expect(utils.flattenStartCase({
         values: [1, 2, {
           nested: 3
-        }],
+        }]
       })).to.deep.equal({
         Values: [1, 2, {
           Nested: 3
-        }],
-      });
-    });
+        }]
+      })
+    })
 
     it('should leave nested arrays nested', () => {
       chai.expect(utils.flattenStartCase(
         [1, 2, [3, 4]])
-      ).to.deep.equal([1, 2, [3, 4]]);
-    });
-  });
+      ).to.deep.equal([1, 2, [3, 4]])
+    })
+  })
 
   describe('.hideAbsolutePathsInObject()', () => {
     it('should return undefined if given undefined', () => {
-      chai.expect(utils.hideAbsolutePathsInObject(undefined)).to.be.undefined;
-    });
+      chai.expect(utils.hideAbsolutePathsInObject(undefined)).to.equal(undefined)
+    })
 
     it('should return null if given null', () => {
-      chai.expect(utils.hideAbsolutePathsInObject(null)).to.be.null;
-    });
+      chai.expect(utils.hideAbsolutePathsInObject(null)).to.equal(null)
+    })
 
     it('should return a clone of the object if there are no paths in the object', () => {
       const object = {
@@ -152,87 +152,87 @@ describe('Utils', () => {
         nested: {
           otherProperty: 'value'
         }
-      };
-      chai.expect(utils.hideAbsolutePathsInObject(object)).to.not.equal(object);
-      chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal(object);
-    });
+      }
+      chai.expect(utils.hideAbsolutePathsInObject(object)).to.not.equal(object)
+      chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal(object)
+    })
 
-    it('should return a plain object when given an error object', function() {
-      const error = new Error('Hello, World!');
-      const hiddenPaths = utils.hideAbsolutePathsInObject(error);
+    it('should return a plain object when given an error object', function () {
+      const error = new Error('Hello, World!')
+      const hiddenPaths = utils.hideAbsolutePathsInObject(error)
 
       chai.expect(hiddenPaths).to.deep.equal({
         message: 'Hello, World!',
         stack: error.stack
-      });
-    });
+      })
+    })
 
     describe('given UNIX paths', () => {
       beforeEach(() => {
-        this.isAbsolute = path.isAbsolute;
-        this.basename = path.basename;
-        path.isAbsolute = path.posix.isAbsolute;
-        path.basename = path.posix.basename;
-      });
+        this.isAbsolute = path.isAbsolute
+        this.basename = path.basename
+        path.isAbsolute = path.posix.isAbsolute
+        path.basename = path.posix.basename
+      })
 
       afterEach(() => {
-        path.isAbsolute = this.isAbsolute;
-        path.basename = this.basename;
-      });
+        path.isAbsolute = this.isAbsolute
+        path.basename = this.basename
+      })
 
       it('should replace absolute paths with the basename', () => {
         const object = {
           prop1: 'some value',
           prop2: '/home/john/rpi.img'
-        };
+        }
 
         chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal({
           prop1: 'some value',
           prop2: 'rpi.img'
-        });
-      });
+        })
+      })
 
       it('should replace nested absolute paths with the basename', () => {
         const object = {
           nested: {
             path: '/home/john/rpi.img'
           }
-        };
+        }
 
         chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal({
           nested: {
             path: 'rpi.img'
           }
-        });
-      });
+        })
+      })
 
       it('should not alter /dev/sdb', () => {
         const object = {
           nested: {
             path: '/dev/sdb'
           }
-        };
+        }
 
         chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal({
           nested: {
             path: '/dev/sdb'
           }
-        });
-      });
+        })
+      })
 
       it('should work on strings', () => {
-        chai.expect(utils.hideAbsolutePathsInObject('path /home/john/rpi.img')).to.deep.equal('path rpi.img');
-      });
+        chai.expect(utils.hideAbsolutePathsInObject('path /home/john/rpi.img')).to.deep.equal('path rpi.img')
+      })
 
       it('should not alter relative paths', () => {
         const object = {
           path: 'foo/bar'
-        };
+        }
 
         chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal({
           path: 'foo/bar'
-        });
-      });
+        })
+      })
 
       it('should handle arrays', () => {
         chai.expect(utils.hideAbsolutePathsInObject({
@@ -261,72 +261,72 @@ describe('Utils', () => {
               path: 'baz'
             }
           ]
-        });
-      });
-    });
+        })
+      })
+    })
 
     describe('given Windows paths', () => {
       beforeEach(() => {
-        this.isAbsolute = path.isAbsolute;
-        this.basename = path.basename;
-        path.isAbsolute = path.win32.isAbsolute;
-        path.basename = path.win32.basename;
-      });
+        this.isAbsolute = path.isAbsolute
+        this.basename = path.basename
+        path.isAbsolute = path.win32.isAbsolute
+        path.basename = path.win32.basename
+      })
 
       afterEach(() => {
-        path.isAbsolute = this.isAbsolute;
-        path.basename = this.basename;
-      });
+        path.isAbsolute = this.isAbsolute
+        path.basename = this.basename
+      })
 
       it('should replace absolute paths with the basename', () => {
         const object = {
           prop1: 'some value',
           prop2: 'C:\\Users\\John\\rpi.img'
-        };
+        }
 
         chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal({
           prop1: 'some value',
           prop2: 'rpi.img'
-        });
-      });
+        })
+      })
 
       it('should replace nested absolute paths with the basename', () => {
         const object = {
           nested: {
             path: 'C:\\Users\\John\\rpi.img'
           }
-        };
+        }
 
         chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal({
           nested: {
             path: 'rpi.img'
           }
-        });
-      });
+        })
+      })
 
       it('should not alter \\\\.\\PHYSICALDRIVE1', () => {
         const object = {
           nested: {
             path: '\\\\.\\PHYSICALDRIVE1'
           }
-        };
+        }
 
         chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal({
           nested: {
             path: '\\\\.\\PHYSICALDRIVE1'
           }
-        });
-      });
+        })
+      })
 
       it('should not alter relative paths', () => {
         const object = {
           path: 'foo\\bar'
-        };
+        }
 
         chai.expect(utils.hideAbsolutePathsInObject(object)).to.deep.equal({
           path: 'foo\\bar'
-        });
-      });
+        })
+      })
 
       it('should handle arrays', () => {
         chai.expect(utils.hideAbsolutePathsInObject({
@@ -347,98 +347,97 @@ describe('Utils', () => {
           }, {
             path: 'baz'
           }]
-        });
-      });
-    });
-  });
+        })
+      })
+    })
+  })
 
   describe('.shouldReport()', () => {
     it('should return true for a string error', () => {
-      const error = 'foo';
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = 'foo'
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for a number 0 error', () => {
-      const error = 0;
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = 0
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for a number 1 error', () => {
-      const error = 1;
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = 1
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for a number -1 error', () => {
-      const error = -1;
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = -1
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for an array error', () => {
-      const error = [1, 2, 3];
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = [1, 2, 3]
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for an undefined error', () => {
-      const error = undefined;
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = undefined
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for a null error', () => {
-      const error = null;
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = null
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for an empty object error', () => {
-      const error = {};
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = {}
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for a basic error', () => {
-      const error = new Error('foo');
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = new Error('foo')
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return true for an error with a report true property', () => {
-      const error = new Error('foo');
-      error.report = true;
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = new Error('foo')
+      error.report = true
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should return false for an error with a report false property', () => {
-      const error = new Error('foo');
-      error.report = false;
-      chai.expect(utils.shouldReportError(error)).to.be.false;
-    });
+      const error = new Error('foo')
+      error.report = false
+      chai.expect(utils.shouldReportError(error)).to.equal(false)
+    })
 
     it('should return false for an error with a report undefined property', () => {
-      const error = new Error('foo');
-      error.report = undefined;
-      chai.expect(utils.shouldReportError(error)).to.be.false;
-    });
+      const error = new Error('foo')
+      error.report = undefined
+      chai.expect(utils.shouldReportError(error)).to.equal(false)
+    })
 
     it('should return false for an error with a report null property', () => {
-      const error = new Error('foo');
-      error.report = null;
-      chai.expect(utils.shouldReportError(error)).to.be.false;
-    });
+      const error = new Error('foo')
+      error.report = null
+      chai.expect(utils.shouldReportError(error)).to.equal(false)
+    })
 
     it('should return false for an error with a report 0 property', () => {
-      const error = new Error('foo');
-      error.report = 0;
-      chai.expect(utils.shouldReportError(error)).to.be.false;
-    });
+      const error = new Error('foo')
+      error.report = 0
+      chai.expect(utils.shouldReportError(error)).to.equal(false)
+    })
 
     it('should return true for an error with a report 1 property', () => {
-      const error = new Error('foo');
-      error.report = 1;
-      chai.expect(utils.shouldReportError(error)).to.be.true;
-    });
+      const error = new Error('foo')
+      error.report = 1
+      chai.expect(utils.shouldReportError(error)).to.equal(true)
+    })
 
     it('should cast the report property to boolean', () => {
-      const error = new Error('foo');
-      error.report = '';
-      chai.expect(utils.shouldReportError(error)).to.be.false;
-    });
-  });
-});
-
+      const error = new Error('foo')
+      error.report = ''
+      chai.expect(utils.shouldReportError(error)).to.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
This switches the linter from eslint with airbnb's base config
to standard, and adds linter runs to the CI builds, while also
testing across Node versions 4, 6, and 8.

Change-Type: patch