### PR TITLE
fix(sentry): Only use transports when in Node

### DIFF
--- a/src/sentry.js
+++ b/src/sentry.js
@@ -66,12 +66,13 @@ module.exports = (SentryLib) => {
       }
 
       const sentryConfig = _.cloneDeep(config)
+      const transport = SentryLib.transports && SentryLib.transports.https
 
       _.defaults(sentryConfig, {
         autoBreadcrumbs: true,
         allowSecretKey: true,
         dataCallback: utils.hideAbsolutePathsInObject,
-        transport: SentryLib.transports.https
+        transport: transport
       })
 
       _.defaults(sentryConfig.extra, defaultContext[env])


### PR DESCRIPTION
This avoids using the `raven.transports` when in the browser,
where those transports aren't available.

Change-Type: patch
Connects To: #31