### PR TITLE
fix(mixpanel): delay init() call to first tracking event

### DIFF
--- a/src/mixpanel.js
+++ b/src/mixpanel.js
@@ -25,7 +25,8 @@ module.exports = (MixpanelLib) => {
   const env = detect.getName()
 
   const properties = {
-    installed: false
+    installed: false,
+    projectToken: null
   }
 
   const isInstalled = () => properties.installed
@@ -73,7 +74,7 @@ module.exports = (MixpanelLib) => {
         }))
       }
 
-      properties.client = MixpanelLib.init(token, { protocol: 'https' }) || MixpanelLib
+      properties.projectToken = token
       properties.context = utils.flattenStartCase(_.defaults(config, defaultContext[env]))
       properties.installed = true
     },
@@ -108,6 +109,12 @@ module.exports = (MixpanelLib) => {
       }
 
       const context = Object.assign({}, properties.context, utils.flattenStartCase(data))
+
+      if (!properties.client) {
+        properties.client = MixpanelLib.init(properties.projectToken, {
+          protocol: 'https'
+        }) || MixpanelLib
+      }
 
       properties.client.track(message, utils.hideAbsolutePathsInObject(context))
     }

--- a/tests/mixpanel.js
+++ b/tests/mixpanel.js
@@ -41,12 +41,6 @@ describe('Services: Mixpanel', () => {
       mixpanel.install(token)
       chai.expect(() => mixpanel.install(token)).to.throw(Error)
     })
-
-    it('calls MixpanelLib.init() with correct parameters', () => {
-      mixpanel.install(token)
-      chai.expect(MixpanelLib.init.calledOnce).to.equal(true)
-      chai.expect(MixpanelLib.init.calledWith(token)).to.equal(true)
-    })
   })
 
   describe('isInstalled()', () => {


### PR DESCRIPTION
The `.init()` function call causes an HTTP request to
`api.mixpanel.com`, without taking `shouldReport()` into consideration.
For this reason, we delay initializing the client to the moment where we
need to send a first tracking event.

See: https://github.com/resin-io/etcher/issues/1772
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>