### PR TITLE
Ensure default context is passed to Sentry

### DIFF
--- a/src/sentry.js
+++ b/src/sentry.js
@@ -75,7 +75,9 @@ module.exports = (SentryLib) => {
         transport: transport
       })
 
-      _.defaults(sentryConfig.extra, defaultContext[env])
+      _.merge(sentryConfig, {
+        extra: defaultContext[env]
+      })
 
       properties.client = SentryLib.config(dsn, sentryConfig).install()
       properties.installed = true


### PR DESCRIPTION
The `sentryConfig.extra` property is `undefined`, and using `_.defaults`
over an undefined property is a no-op.

By doing a `_.merge`, we also make sure the extra properties remain in
there even if the `.extra` property happens to exist for any reason.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>