### PR TITLE
Remove cyclic references in objects passed to hideAbsolutePathsInObject

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "detect-process": "^1.0.4",
     "electron-is-running-in-asar": "^1.0.0",
     "flat": "^4.0.0",
+    "json-cycle": "^1.3.0",
     "lodash": "^4.17.4",
     "lodash-deep": "^2.0.0",
     "mixpanel": "^0.10.1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,7 @@
 
 'use strict'
 
+const jc = require('json-cycle')
 const _ = require('lodash')
 _.mixin(require('lodash-deep'))
 const flatten = require('flat').flatten
@@ -129,6 +130,9 @@ exports.hideAbsolutePathsInObject = (object) => {
     const words = object.split(' ').map(word => (path.isAbsolute(word) ? path.basename(word) : word))
     return words.join(' ')
   }
+
+  // Avoid "Maximum call stack size exceeded" errors
+  object = jc.decycle(object)
 
   return _.deepMapValues(object, (value) => {
     if (!_.isString(value)) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -132,6 +132,12 @@ describe('Utils', () => {
       chai.expect(utils.hideAbsolutePathsInObject(null)).to.equal(null)
     })
 
+    it('should remove circular references', () => {
+      const obj = {}
+      obj.circular = obj
+      chai.expect(utils.hideAbsolutePathsInObject(obj)).to.deep.equal({ circular: { $ref: '$' } })
+    })
+
     it('should return a clone of the object if there are no paths in the object', () => {
       const object = {
         numberProperty: 1,


### PR DESCRIPTION
This should prevent "Maximum call stack size exceeded" errors

Change-type: patch